### PR TITLE
Update checks for UrlMatcher

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,6 @@
 {
     "editor.codeActionsOnSave": {
-        "source.fixAll.stylelint": true
+        "source.fixAll.stylelint": "explicit"
     },
     "prettier.enable": true,
     "editor.defaultFormatter": "esbenp.prettier-vscode",

--- a/src/Matchers/UrlMatcher.php
+++ b/src/Matchers/UrlMatcher.php
@@ -43,7 +43,7 @@ class UrlMatcher implements FakeResponseMatcherContract
             return false;
         }
 
-        return $this->body !== $request->getBody()->getContents();
+        return $this->body != $request->getBody()->getContents();
     }
 
     private function requestMethodDifferent(RequestInterface $request): bool


### PR DESCRIPTION
The UrlMatcher was failing to match when using json POST data

I tweaked the following to check the data

```
   private function requestBodyDifferent(RequestInterface $request): bool
    {
        if (is_null($this->body)) {
            // Skip if no body provided to check
            return false;
        }

        dump("{$this->body}");
        dump("{$request->getBody()->getContents()}");
        return $this->body !== $request->getBody()->getContents();
    }
```

and the two lines were the same but the check failed
```
"{"client_id":"clientID","client_secret":"secret","grant_type":"client_credentials","response_type":"token","scope":"login"}" // vendor/tomb1n0/generic-api-client/src/Matchers/UrlMatcher.php:46
"{"client_id":"clientID","client_secret":"secret","grant_type":"client_credentials","response_type":"token","scope":"login"}" // vendor/tomb1n0/generic-api-client/src/Matchers/UrlMatcher.php:47
```

I updated to `!=` and the test passed

I think there can be a case where the types are somehow different. We could cast the values but using `!=` seems okay (and we do this in requestMethodDifferent already)